### PR TITLE
introduce initializers to several contracts

### DIFF
--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -7,6 +7,7 @@ import {IERC20} from "./IERC20.sol";
 import {IERC20Metadata} from "./extensions/IERC20Metadata.sol";
 import {Context} from "../../utils/Context.sol";
 import {IERC20Errors} from "../../interfaces/draft-IERC6093.sol";
+import {Initializable} from "../../proxy/utils/Initializable.sol";
 
 /**
  * @dev Implementation of the {IERC20} interface.
@@ -35,7 +36,7 @@ import {IERC20Errors} from "../../interfaces/draft-IERC6093.sol";
  * functions have been added to mitigate the well-known issues around setting
  * allowances. See {IERC20-approve}.
  */
-abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
+abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors, Initializable {
     mapping(address => uint256) private _balances;
 
     mapping(address => mapping(address => uint256)) private _allowances;
@@ -56,7 +57,11 @@ abstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {
      * All two of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor(string memory name_, string memory symbol_) {
+    constructor(string memory name_, string memory symbol_) initializer {
+        initialize(name_, symbol_);
+    }
+
+    function initialize(string memory name_, string memory symbol_) public onlyInitializing {
         _name = name_;
         _symbol = symbol_;
     }

--- a/contracts/token/ERC20/extensions/ERC20Permit.sol
+++ b/contracts/token/ERC20/extensions/ERC20Permit.sol
@@ -8,6 +8,7 @@ import {ERC20} from "../ERC20.sol";
 import {ECDSA} from "../../../utils/cryptography/ECDSA.sol";
 import {EIP712} from "../../../utils/cryptography/EIP712.sol";
 import {Nonces} from "../../../utils/Nonces.sol";
+import {Initializable} from "../../../proxy/utils/Initializable.sol";
 
 /**
  * @dev Implementation of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
@@ -19,7 +20,7 @@ import {Nonces} from "../../../utils/Nonces.sol";
  */
 abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {
     // solhint-disable-next-line var-name-mixedcase
-    bytes32 private constant _PERMIT_TYPEHASH =
+    bytes32 internal _PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
     /**
@@ -38,6 +39,11 @@ abstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {
      * It's a good idea to use the same `name` that is defined as the ERC20 token name.
      */
     constructor(string memory name) EIP712(name, "1") {}
+
+    function initialize(string memory name, string memory symbol) public virtual onlyInitializing {
+        EIP712.initialize(name, "1");
+        ERC20.initialize(name, symbol);
+    }
 
     /**
      * @dev See {IERC20Permit-permit}.

--- a/contracts/utils/cryptography/EIP712.sol
+++ b/contracts/utils/cryptography/EIP712.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.19;
 import {MessageHashUtils} from "./MessageHashUtils.sol";
 import {ShortStrings, ShortString} from "../ShortStrings.sol";
 import {IERC5267} from "../../interfaces/IERC5267.sol";
+import {Initializable} from "../../proxy/utils/Initializable.sol";
 
 /**
  * @dev https://eips.ethereum.org/EIPS/eip-712[EIP 712] is a standard for hashing and signing of typed structured data.
@@ -31,7 +32,7 @@ import {IERC5267} from "../../interfaces/IERC5267.sol";
  *
  * @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
  */
-abstract contract EIP712 is IERC5267 {
+abstract contract EIP712 is IERC5267, Initializable {
     using ShortStrings for *;
 
     bytes32 private constant _TYPE_HASH =
@@ -39,15 +40,15 @@ abstract contract EIP712 is IERC5267 {
 
     // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
     // invalidate the cached domain separator if the chain id changes.
-    bytes32 private immutable _cachedDomainSeparator;
-    uint256 private immutable _cachedChainId;
-    address private immutable _cachedThis;
+    bytes32 private _cachedDomainSeparator;
+    uint256 private _cachedChainId;
+    address private _cachedThis;
 
-    bytes32 private immutable _hashedName;
-    bytes32 private immutable _hashedVersion;
+    bytes32 private _hashedName;
+    bytes32 private _hashedVersion;
 
-    ShortString private immutable _name;
-    ShortString private immutable _version;
+    ShortString private _name;
+    ShortString private _version;
     string private _nameFallback;
     string private _versionFallback;
 
@@ -63,7 +64,11 @@ abstract contract EIP712 is IERC5267 {
      * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart
      * contract upgrade].
      */
-    constructor(string memory name, string memory version) {
+    constructor(string memory name, string memory version) initializer {
+        initialize(name, version);
+    }
+
+    function initialize(string memory name, string memory version) public virtual onlyInitializing {
         _name = name.toShortStringWithFallback(_nameFallback);
         _version = version.toShortStringWithFallback(_versionFallback);
         _hashedName = keccak256(bytes(name));

--- a/package-lock.json
+++ b/package-lock.json
@@ -15417,9 +15417,8 @@
       "license": "MIT"
     },
     "scripts/solhint-custom": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
+      "name": "solhint-plugin-openzeppelin",
+      "dev": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
in order to initialize cloned contracts that inherit from other contracts, most of these contracts need initializers. I added some. This is not finished yet.